### PR TITLE
add repos (including ssb repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scuttlebutt Protocol Guide
-
 - [Read online](https://vltf.org/scuttlebuttprotocolguide)
 - [Dev diary](https://vltf.org/scuttlebuttprotocolguide/diary.html)
+- Repos: [ssb](%gghZe88ZC2N18Zz44cn0/PE12eEJ+vyzOj6CW1QG4Ds=.sha256) | [github](https://github.com/vtduncan/scuttlebutt-protocol-guide)
 
 ## Public Domain
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scuttlebutt Protocol Guide
 - [Read online](https://vltf.org/scuttlebuttprotocolguide)
 - [Dev diary](https://vltf.org/scuttlebuttprotocolguide/diary.html)
-- Repos: [ssb](%gghZe88ZC2N18Zz44cn0/PE12eEJ+vyzOj6CW1QG4Ds=.sha256) | [github](https://github.com/vtduncan/scuttlebutt-protocol-guide)
+- Repos: [ssb](ssb://%gghZe88ZC2N18Zz44cn0/PE12eEJ+vyzOj6CW1QG4Ds=.sha256) | [github](https://github.com/vtduncan/scuttlebutt-protocol-guide)
 
 ## Public Domain
 


### PR DESCRIPTION
hey @vtduncan I've added the git ssb repo location. This means people can use git-ssb to pull and push content to it. If you've not done this before, I'm happy to show you how ... it's as simple as 

```
npm install git-ssb -g
```

/while running a sbot (or patchwork):
```
git clone ssb://%gghZe88ZC2N18Zz44cn0/PE12eEJ+vyzOj6CW1QG4Ds=.sha256 scuttlebutt-protocol-guide

// or: 
// git remote add ssb ssb://%gghZe88ZC2N18Zz44cn0/PE12eEJ+vyzOj6CW1QG4Ds=.sha256

// make some changes
git push ssb master
```
