### PR TITLE
Fix invalid response arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,7 +745,7 @@ assert_nacl_sign_verify_detached(
         <p>The responder does in fact have this blob so they respond with <code>true</code>. Because this is an async procedure and not a stream, there is only one response and no need to close the stream afterwards:</p>
 
         <figure class="request-response">
-            <img class="response-arrow" src="img/arrow.png alt="""/>
+            <img class="response-arrow" src="img/arrow.png" alt=""/>
             <div class="response">
                 <div class="header">
                     <span class="key">Request number</span><span class="value">-2</span>


### PR DESCRIPTION
Due to incorrectly placed quotation marks the image is not rendered correctly.